### PR TITLE
Fix crash when photoAsset.location is nil

### DIFF
--- a/LivelyGIFs/LivePhotoVC.swift
+++ b/LivelyGIFs/LivePhotoVC.swift
@@ -56,12 +56,14 @@ class LivePhotoVC: UIViewController {
                     self.photoView.livePhoto = livePhoto
                     self.photoView.startPlayback(with: .hint)
                     
-                    let geoCoder = CLGeocoder()
-                    geoCoder.reverseGeocodeLocation(photoAsset.location!, completionHandler: { (placemark: [CLPlacemark]?, error: Error?) in
-                        if error == nil {
-                            self.navigationItem.title = placemark?.first?.locality
-                        }
-                    })
+                    if let photoLocation = photoAsset.location {
+                        let geoCoder = CLGeocoder()
+                        geoCoder.reverseGeocodeLocation(photoLocation, completionHandler: { (placemark: [CLPlacemark]?, error: Error?) in
+                            if error == nil {
+                                self.navigationItem.title = placemark?.first?.locality
+                            }
+                        })
+                    }
                 }
             })
         }


### PR DESCRIPTION
Hello, your Repo looks great. However, when I try it,  a crash happen. Because photoAsset.location may be nil if someone download the livephoto from the internet which do not have the location info. If you like it ,feel free to merge.